### PR TITLE
Add Support to Save Uploads onto Daily Folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ To Create Date Level Folders update the date format config. By Default this is s
 Using the Service User OAuth (p12 file) means that the files are created and owned by the service user<br/>
 When using folders that means we need to set the folder permission explicitly.<br/>
 By Default the ```gmail/user``` from config is set as a writer. To add any other users set the ```read_users``` and ```write_users``` values in config. 
-These values should be the same as the    
+These values should be the email addresses of the users you wish to permission.
 
 ## TODO
 

--- a/README.md
+++ b/README.md
@@ -54,13 +54,35 @@ sudo mkdir /etc/motion-notify
 Copy ```motion-notify.cfg```, ```motion-notify.py``` and ```create-motion-conf-entries.txt``` to the directory you created
 
 Create the log file and set the permissions
+
 ```bash
 sudo touch /var/tmp/motion-notify.log
 sudo chown motion.motion /var/tmp/motion-notify.log
 sudo chmod 664 /var/tmp/motion-notify.log
 ```
 
-## Configurations
+Update Configuration (see Configuration Section)
+
+Change the File permissions
+
+```bash
+sudo chown motion.motion /etc/motion-notify/motion-notify.py
+sudo chown motion.motion /etc/motion-notify/motion-notify.cfg
+sudo chmod 744 motion.motion /etc/motion-notify/motion-notify.py
+sudo chmod 600 motion.motion /etc/motion-notify/motion-notify.cfg
+```
+
+Create the entry in the Motion conf file to trigger the motion-notify script when there is an alert
+
+```bash
+sudo cat /etc/motion-notify/create-motion-conf-entries.txt >> /etc/motion/motion.conf
+rm /etc/motion-notify/create-motion-conf-entries.txt
+```
+
+Motion will now send alerts to you when you're devices aren't present on the network
+
+
+## Configuration
 
 ### Google Drive Config
 
@@ -108,20 +130,19 @@ Enter the following configuration for emails:
 - The hours that you always want to receive email alerts even when you're home
 - Either enter IP addresses or MAC addresses (avoid using MAC addresses) which will be active when you're at home
 
-Change the permissions
+### Sub Folder Config
 
-```bash
-sudo chown motion.motion /etc/motion-notify/motion-notify.py
-sudo chown motion.motion /etc/motion-notify/motion-notify.cfg
-sudo chmod 744 motion.motion /etc/motion-notify/motion-notify.py
-sudo chmod 600 motion.motion /etc/motion-notify/motion-notify.cfg
-```
+To Create Date Level Folders update the date format config. By Default this is set to roll each day. (See Permissions)
 
-Create the entry in the Motion conf file to trigger the motion-notify script when there is an alert
+### Permissions Config
 
-```bash
-sudo cat /etc/motion-notify/create-motion-conf-entries.txt >> /etc/motion/motion.conf
-rm /etc/motion-notify/create-motion-conf-entries.txt
-```
+Using the Service User OAuth (p12 file) means that the files are created and owned by the service user<br/>
+When using folders that means we need to set the folder permission explicitly.<br/>
+By Default the ```gmail/user``` from config is set as a writer. To add any other users set the ```read_users``` and ```write_users``` values in config. 
+These values should be the same as the    
 
-Motion will now send alerts to you when you're devices aren't present on the network
+## TODO
+
+- Set Owner Of Date Folders to be the real owner and not the service user
+- remove need for folder_name by searching for folder id
+- update datefolder search to include root folder as parent

--- a/README.md
+++ b/README.md
@@ -1,90 +1,127 @@
-motion-notify
-=============
+#motion-notify
 
 Motion Notify is a notification system for Linux Motion providing upload to Google Drive and email notificaiton when you're not home.
+
 This carries out the following:
 
--Sends an email when motion detection event starts
--Uploads images to Google Drive whilst an event is occuring
--Uploads a video to Google Drive when the event ends
--Sends an email when the event ends with a link to the video
--Detects whether you're at home by looking for certain IP addresses on your local network and doesn't send alerts if you're home
--Allows you to specify hours when you want to receive alerts even if you're at home
+- Sends an email when motion detection event starts
+- Uploads images to Google Drive whilst an event is occuring
+- Uploads a video to Google Drive when the event ends
+- Sends an email when the event ends with a link to the video
+- Detects whether you're at home by looking for certain IP addresses on your local network and doesn't send alerts if you're home
+- Allows you to specify hours when you want to receive alerts even if you're at home
+- Only receive alerts when you're not home
 
-Only receive alerts when you're not home
+## IP Check
+
 The script detects whether you're at home by checking the network for the presence of certain devices by IP address or MAC address.
-It's highly recommended to use IP rather than MAC. If you choose to use MAC you will need to run the script (and Motion) as root as it uses ARP - this isn't recommended. IP detection uses ping so will run as a regular user.
-Specify either a comma separated list of IP addresses or a comma separated list of MAC addresses. IP addresses take priority so if you specify those, the MAC addresses will be ignored.
-Note that mobile phones often don't retain a constant connection to the wireless network even though they show that they are connected. They tend to sleep and then just reconnect occassionally to reduce battery life.
+
+It's highly recommended to use IP rather than MAC. If you choose to use MAC you will need to run the script (and Motion) as root as it uses ARP - this isn't recommended.
+
+IP detection uses ping so will run as a regular user.
+
+Specify either a comma separated list of IP addresses or a comma separated list of MAC addresses.
+IP addresses take priority so if you specify those, the MAC addresses will be ignored.
+
+Note that mobile phones often don't retain a constant connection to the wireless network even though they show that they are connected.
+They tend to sleep and then just reconnect occassionally to reduce battery life.
 This means that you might get a lot of false alarms if you just use a mobile phone IP address.
+
 Adding lots of devices that are only active when you're at home will reduce false alarms - try things like your Smart TV, desktop PC etc as well as any mobile phones.
 A later release will include improvements to not just check if a device is present but also to check if a device has been present in the last X number of minutes.
 It's highly recommended to configure your devices to use static IP's to prevent the IP addresses from changing.
 
 
-Installation
+## Installation
 
 Install Python Libraries
+
+```bash
 sudo apt-get update
 sudo apt-get install python-pip
 sudo pip install PyDrive
 sudo pip install oauth2client
 sudo pip install google-api-python-client
 sudo apt-get install python-openssl
+```
 
 Create a directory:
-sudo mkdir /etc/motion-notify
 
-Copy motion-notify.cfg, motion-notify.py and create-motion-conf-entries.txt to the directory you created
+```bash
+sudo mkdir /etc/motion-notify
+```
+
+Copy ```motion-notify.cfg```, ```motion-notify.py``` and ```create-motion-conf-entries.txt``` to the directory you created
 
 Create the log file and set the permissions
+```bash
 sudo touch /var/tmp/motion-notify.log
 sudo chown motion.motion /var/tmp/motion-notify.log
 sudo chmod 664 /var/tmp/motion-notify.log
+```
 
+## Configurations
 
-Configurations
+### Google Drive Config
 
-Google Drive Config
 Google drive authentication is done using a service account via key authentication. The service account is given access only to the folder you specify in Google Drive.
 
-Login to Google Drive and create a folder where images and video will be upload to
-Enter the ID of the folder into the "folder" field in the config file (if the URL of the folder is https://drive.google.com/drive/folders/0Bzt4FJyYHjdYhnA3cECdTFW3RWM then the ID is 0Bzt4FJyYHjdYhnA3cECdTFW3RWM.
+- Login to Google Drive and create a folder where images and video will be upload to
+- Enter the ID of the folder into the "folder" field in the config file.<br/>
+  If the URL of the folder is https://drive.google.com/drive/folders/0Bzt4FJyYHjdYhnA3cECdTFW3RWM then the ID is 0Bzt4FJyYHjdYhnA3cECdTFW3RWM.
+
 Next you need to get some account credentials from the Google Developers console - this will allow motion-notify to upload files to Google Drive.
-Go to https://console.developers.google.com/
-From the "Select a project" dropdown at the top of the page choose "Create a project"
-Enter "motion-notify" as the project name (or anything else that you want to call it)
+
+- Go to https://console.developers.google.com/
+- From the "Select a project" dropdown at the top of the page choose "Create a project"
+- Enter "motion-notify" as the project name (or anything else that you want to call it)
+
 Once the project is created you'll be take to the project dashboard for that project.
-Go to APIs & auth > APIs > Drive API and click "Enable API"
-Go to APIs & auth > Credentials and choose "Create new Client ID" and select "Service Account" as the application type.
+
+- Go to APIs & auth > APIs > Drive API and click "Enable API"
+- Go to APIs & auth > Credentials and choose "Create new Client ID" and select "Service Account" as the application type.
+
 You'll receive a download containing a JSON file.
-Generate a new P12 key for the service account you just created using the button underneath the details of the service account. Save this file in the /etc/motion-notify directory and rename it to cred.p12.
-The service account has an email address associated with it which will @developer.gserviceaccount.com. Copy that email address and enter it into the "service_user_email" field in the config file.
+
+- Generate a new P12 key for the service account you just created using the button underneath the details of the service account.
+- Save this file in the /etc/motion-notify directory and rename it to cred.p12.
+
+The service account has an email address associated with it which will @developer.gserviceaccount.com.
+Copy that email address and enter it into the "service_user_email" field in the config file.
+
 You now need to allow the service account access to your Google Drive folder.
-    Go to the Google Drive folder where you want images and videos to be uploaded
-    Click on the share icon
-    Enter the email address of your service account and ensure that "Can edit" is selected.
 
+- Go to the Google Drive folder where you want images and videos to be uploaded
+- Click on the share icon
+- Enter the email address of your service account and ensure that "Can edit" is selected.
 
-Email config
+### Email config
+
 Enter the following configuration for emails:
--Google account details into the GMail section of the config file (this is just to send emails so you could setup another Google account just for sending if you're worried about storing your account password in the clear).
--Email address to send alerts to
--The URL of the folder you created in your Google account (just copy and paste it from the browser). This will be sent in the alert emails so that you can click through to the folder
 
-Notification Config
--The hours that you always want to receive email alerts even when you're home
--Either enter IP addresses or MAC addresses (avoid using MAC addresses) which will be active when you're at home
+- Google account details into the GMail section of the config file <br/>
+  (this is just to send emails so you could setup another Google account just for sending if you're worried about storing your account password in the clear).
+- Email address to send alerts to
+- The URL of the folder you created in your Google account (just copy and paste it from the browser). This will be sent in the alert emails so that you can click through to the folder
+
+### Notification Config
+- The hours that you always want to receive email alerts even when you're home
+- Either enter IP addresses or MAC addresses (avoid using MAC addresses) which will be active when you're at home
 
 Change the permissions
+
+```bash
 sudo chown motion.motion /etc/motion-notify/motion-notify.py
 sudo chown motion.motion /etc/motion-notify/motion-notify.cfg
 sudo chmod 744 motion.motion /etc/motion-notify/motion-notify.py
 sudo chmod 600 motion.motion /etc/motion-notify/motion-notify.cfg
+```
 
 Create the entry in the Motion conf file to trigger the motion-notify script when there is an alert
+
+```bash
 sudo cat /etc/motion-notify/create-motion-conf-entries.txt >> /etc/motion/motion.conf
 rm /etc/motion-notify/create-motion-conf-entries.txt
-
+```
 
 Motion will now send alerts to you when you're devices aren't present on the network

--- a/README.md
+++ b/README.md
@@ -146,3 +146,4 @@ These values should be the same as the
 - Set Owner Of Date Folders to be the real owner and not the service user
 - remove need for folder_name by searching for folder id
 - update datefolder search to include root folder as parent
+- Add option to put Video and Pics in seperate folders

--- a/motion-notify.cfg
+++ b/motion-notify.cfg
@@ -19,10 +19,14 @@ google_drive_folder_link = https://drive.google.com/a/xxxxxxxxxxx.com/folderview
 
 [drive]
 # The folder in Google drive to upload to (from the URL eg. https://drive.google.com/drive/folders/0Bzt4FJyYHjdYhnA3cECdTFW3RWM
+folder_name = MOTION
 folder = 0Bzt4FJyYHjdYhnA3cECdTFW3RWM
 #key file - this is the p12 key file downloaded from developers.google.com
 key_file = /etc/motion-notify/creds.p12
 service_user_email = xxxxxxxxxxxxxxxxxxxxxxxxxxx@developer.gserviceaccount.com
+dateformat = %Y-%m-%d
+write_users = youremail@gmail.com,writer@gmail.com
+read_users = reader@gmail.com
 
 [options]
 # Delete the local video and files after the upload

--- a/motionnotifygoogledriveupload.py
+++ b/motionnotifygoogledriveupload.py
@@ -2,6 +2,7 @@ from pydrive.auth import GoogleAuth
 from pydrive.drive import GoogleDrive
 
 import httplib2
+from datetime import datetime
 
 from oauth2client.client import SignedJwtAssertionCredentials
 
@@ -20,12 +21,99 @@ class MotionNotifyGoogleUpload:
         return gauth
 
     @staticmethod
+    def _get_folder_resource(drive,folder):
+        """Find and return the resource whose title matches the given folder."""
+        try:
+            file_list = drive.ListFile({'q': "title='{}' and mimeType contains 'application/vnd.google-apps.folder' and trashed=false".format(folder)}).GetList()
+            if len(file_list) > 0:
+                return file_list[0]
+            else:
+                return None
+        except IndexError:
+            return None
+        except:
+            return None
+
+    @staticmethod
+    def _get_datefolder_resource(drive,formatted_date):
+        """Find and return the resource whose title matches the given folder."""
+        try:
+            file_list = drive.ListFile({'q': "title='{}' and mimeType contains 'application/vnd.google-apps.folder' and trashed=false".format(formatted_date)}).GetList()
+            if len(file_list) > 0:
+                return file_list[0]
+            else:
+                return None
+        except:
+            return None
+
+    @staticmethod
+    def create_permision(user,role):
+        return {
+            'value': user,
+            'type': "user",
+            'role': role
+        }
+
+    @staticmethod
+    def create_subfolder(drive,folder,sfldname,owner,readers, writers):
+        new_folder = drive.CreateFile({'title':'{}'.format(sfldname),
+                                   'mimeType':'application/vnd.google-apps.folder'})
+        if folder is not None:
+            new_folder['parents'] = [{"id": folder['id']}]
+
+        permissions = []
+        owner_permission = MotionNotifyGoogleUpload.create_permision(owner,"owner")
+        write_permissions = [MotionNotifyGoogleUpload.create_permision(x,"writer") for x in writers]
+        read_permissions  = [MotionNotifyGoogleUpload.create_permision(x,"reader") for x in readers]
+
+        permissions.append(owner_permission)
+        permissions.extend(write_permissions)
+        permissions.extend(read_permissions)
+
+        print('Creating Folder {} with permissions {}'.format(sfldname, permissions))
+
+        new_folder["permissions"] = permissions
+        new_folder.Upload()
+        return new_folder
+
+
+    @staticmethod
     def upload(media_file_path, filename, config, mime):
         gauth = MotionNotifyGoogleUpload.authenticate(config)
         drive = GoogleDrive(gauth)
 
+        folder_name = config.get('drive', 'folder_name');
+        folder_id = config.get('drive', 'folder');
+
+        owner = config.get('gmail','user')
+        writers = filter(lambda x:len(x)>0, [x.strip() for x in config.get('drive','write_users').split(",")] )
+        readers = filter(lambda x:len(x)>0, [x.strip() for x in config.get('drive','read_users').split(",")] )
+
+        folder_resource = MotionNotifyGoogleUpload._get_folder_resource(drive,folder_name)
+        if not folder_resource:
+            print('Creating Folder {}'.format(folder_name))
+            folder_resource = MotionNotifyGoogleUpload.create_subfolder(drive,None,folder_name,owner,readers, writers)
+            # raise Exception('Could not find the %s folder' % self.folder)
+
+        print('Using Folder {} {}'.format(folder_name,folder_resource['id']))
+
+        # formatted_date = time.strftime(self.dateformat)
+        senddate=datetime.strftime(datetime.now(), config.get('drive', 'dateformat'))
+
+        # Could / Should Add folder_resource as a parent here.
+        datefolder_resource = MotionNotifyGoogleUpload._get_datefolder_resource(drive,senddate+"c")
+        if not datefolder_resource:
+            print('Creating Date Folder {}'.format(senddate+"c"))
+            datefolder_resource = MotionNotifyGoogleUpload.create_subfolder(drive,folder_resource,senddate+"c",owner,readers, writers)
+
+        print('Using Date Folder {} {}'.format(senddate+"c",datefolder_resource['id']))
+
+        #'title':os.path.basename(file_path)
         gfile = drive.CreateFile({'title': filename, 'mimeType': mime,
-                                  "parents": [{"kind": "drive#fileLink", "id": config.get('drive', 'folder')}]})
+                                  "parents": [{"kind": "drive#fileLink", "id": datefolder_resource['id']}]})
         gfile.SetContentFile(media_file_path)
         gfile.Upload()
+
+        print('Uploaded File  {} {}'.format(filename,gfile['id']))
+
         return '\n\nhttps://drive.google.com/file/d/' + gfile['id'] + '/view?usp=sharing'


### PR DESCRIPTION
Hi 
I've been using this for a while but only recently updated to the OAuth version.

One the issues i always had was the number of files uploaded into a single folder made it impossible to browse back (or find a date of incident you were looking for) 

I've updated the code so that it will create subfolders and save the files in there.
There are issues with permissions, as the folder is owned by the service account who owns the p12 cert, but I've added tha ability to add more users as writers and readers.

Also reformatted the Readme for MD highlighting and spacing.
