### PR TITLE
Improvements to Parent Folder searching and syncronised file uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,5 @@ These values should be the email addresses of the users you wish to permission.
 
 ## TODO
 
-- Set Owner Of Date Folders to be the real owner and not the service user
-- remove need for folder_name by searching for folder id
-- update datefolder search to include root folder as parent
+- Set Owner Of Date Folders to be the real owner and not the service user (Not sure this is possible)
 - Add option to put Video and Pics in seperate folders

--- a/motion-notify.cfg
+++ b/motion-notify.cfg
@@ -25,7 +25,7 @@ folder = 0Bzt4FJyYHjdYhnA3cECdTFW3RWM
 key_file = /etc/motion-notify/creds.p12
 service_user_email = xxxxxxxxxxxxxxxxxxxxxxxxxxx@developer.gserviceaccount.com
 dateformat = %Y-%m-%d
-write_users = youremail@gmail.com,writer@gmail.com
+write_users = writer@gmail.com,writer2@gmail.com
 read_users = reader@gmail.com
 
 [options]

--- a/motion-notify.cfg
+++ b/motion-notify.cfg
@@ -35,6 +35,10 @@ delete-files = true
 # Send an email after the upload
 send-email = true
 
+# Boolean to enable locking to syncronise uploads so only one is in progress at a time
+# Useful when running with limited bandwidth
+mutex-enabled = true
+
 [activate-system]
 # Force on between these hours, i.e, ignore presence info
 force_on_start = 1

--- a/motion-notify.py
+++ b/motion-notify.py
@@ -124,7 +124,7 @@ class MotionNotify:
     def _upload(self, media_file_path, eventId, eventTime, fileType):
         '''Upload the media and return the URL'''
         logger.info('Uploading image %s ' % media_file_path)
-        if (media_file_path.endswith("jpg")):
+        if (media_file_path.endswith( ("jpg","png","gif","bmp") )):
             mimeType = "image/" + fileType
         else :
             mimeType = "video/" + fileType

--- a/motionnotifygoogledriveupload.py
+++ b/motionnotifygoogledriveupload.py
@@ -7,11 +7,13 @@ from datetime import datetime
 
 from oauth2client.client import SignedJwtAssertionCredentials
 
-logger = logging.getLogger( 'MotionNotifyGoogleUpload')
+logger = logging.getLogger( 'MotionNotify.GoogleUpload')
+#logger.setLevel( logging.DEBUG )
 
 class MotionNotifyGoogleUpload:
     @staticmethod
     def authenticate(config):
+        logger.debug("OAuth2 Authentication - Starting")
         svc_user_id = config.get('drive', 'service_user_email')
         svc_scope = "https://www.googleapis.com/auth/drive"
         svc_key_file = config.get('drive', 'key_file')
@@ -20,27 +22,32 @@ class MotionNotifyGoogleUpload:
         gcredentials.authorize(httplib2.Http())
         gauth = GoogleAuth()
         gauth.credentials = gcredentials
+        logger.debug("OAuth2 Authentication - Complete")
         return gauth
 
     @staticmethod
-    def _get_folder_resource(drive,folder):
+    def _get_folder_resource(drive,folder_name,folder_id):
         """Find and return the resource whose title matches the given folder."""
         try:
-            file_list = drive.ListFile({'q': "title='{}' and mimeType contains 'application/vnd.google-apps.folder' and trashed=false".format(folder)}).GetList()
-            if len(file_list) > 0:
-                return file_list[0]
-            else:
-                return None
+            myfile = drive.CreateFile({'id': folder_id})
+            logger.debug ("Found Parent Folder title: {}, mimeType: {}".format(myfile['title'], myfile['mimeType']) )
+            return  myfile
+
+            #file_list = drive.ListFile({'q': "title='{}' and mimeType contains 'application/vnd.google-apps.folder' and trashed=false".format(folder_name)}).GetList()
+            #if len(file_list) > 0:
+            #    return file_list[0]
+            #else:
+            #    return None
         except IndexError:
             return None
         except:
             return None
 
     @staticmethod
-    def _get_datefolder_resource(drive,formatted_date):
+    def _get_datefolder_resource(drive,formatted_date, parent_id):
         """Find and return the resource whose title matches the given folder."""
         try:
-            file_list = drive.ListFile({'q': "title='{}' and mimeType contains 'application/vnd.google-apps.folder' and trashed=false".format(formatted_date)}).GetList()
+            file_list = drive.ListFile({'q': "title='{}' and '{}' in parents and mimeType contains 'application/vnd.google-apps.folder' and trashed=false".format(formatted_date,parent_id)}).GetList()
             if len(file_list) > 0:
                 return file_list[0]
             else:
@@ -61,18 +68,18 @@ class MotionNotifyGoogleUpload:
         new_folder = drive.CreateFile({'title':'{}'.format(sfldname),
                                    'mimeType':'application/vnd.google-apps.folder'})
         if folder is not None:
-            new_folder['parents'] = [{"id": folder['id']}]
+            new_folder['parents'] = [{"kind": "drive#fileLink","id": folder['id']}]
 
         permissions = []
         owner_permission = MotionNotifyGoogleUpload.create_permision(owner,"owner")
-        write_permissions = [MotionNotifyGoogleUpload.create_permision(x,"writer") for x in writers]
+        write_permissions = [MotionNotifyGoogleUpload.create_permision(x,"owner") for x in writers]
         read_permissions  = [MotionNotifyGoogleUpload.create_permision(x,"reader") for x in readers]
 
         permissions.append(owner_permission)
         permissions.extend(write_permissions)
         permissions.extend(read_permissions)
 
-        print('Creating Folder {} with permissions {}'.format(sfldname, permissions))
+        logger.debug('Creating Folder {} with permissions {}'.format(sfldname, permissions))
 
         new_folder["permissions"] = permissions
         new_folder.Upload()
@@ -92,20 +99,25 @@ class MotionNotifyGoogleUpload:
         owner = config.get('gmail','user')
         writers = filter(lambda x:len(x)>0, [x.strip() for x in config.get('drive','write_users').split(",")] )
         readers = filter(lambda x:len(x)>0, [x.strip() for x in config.get('drive','read_users').split(",")] )
-        writers.append(owner)
+        #Keep Owner Seperate # Remove Just in case
+        if owner in writers:
+            writers.remove(owner);
 
         # Check Root Folder Exists
-        folder_resource = MotionNotifyGoogleUpload._get_folder_resource(drive,folder_name)
+        folder_resource = MotionNotifyGoogleUpload._get_folder_resource(drive,folder_name,folder_id)
         if not folder_resource:
-            logger.info('Creating Folder {}'.format(folder_name))
-            folder_resource = MotionNotifyGoogleUpload.create_subfolder(drive,None,folder_name,owner,readers, writers)
-            # raise Exception('Could not find the %s folder' % self.folder)
+            #logger.info('Creating Folder {}'.format(folder_name))
+            # This seemed to create lots of folders I'd no access to, so changing to an Exception
+            # Might need some way to set it to the root of the gmail user and not the service user
+            #folder_resource = MotionNotifyGoogleUpload.create_subfolder(drive,None,folder_name,owner,readers, writers)
+            logger.error("Could not find the {} folder {}".format(folder_name,folder_id) )
+            raise Exception("Could not find the {} folder {}".format(folder_name,folder_id) )
 
         logger.debug('Using Folder {} {}'.format(folder_name,folder_resource['id']))
 
         # Check Date Folder Exists & Create / Use as needed
-        senddate=datetime.strftime(datetime.now(), config.get('drive', 'dateformat'))
-        datefolder_resource = MotionNotifyGoogleUpload._get_datefolder_resource(drive,senddate)
+        senddate=(datetime.strftime(datetime.now(), config.get('drive', 'dateformat')))
+        datefolder_resource = MotionNotifyGoogleUpload._get_datefolder_resource(drive,senddate,folder_resource['id'])
         if not datefolder_resource:
             logger.info('Creating Date Folder {}'.format(senddate))
             datefolder_resource = MotionNotifyGoogleUpload.create_subfolder(drive,folder_resource,senddate,owner,readers, writers)


### PR DESCRIPTION
Couple of changes. First set were to fix issues where it could create more than one parent folder because it didn't use the Folder ID to search. 
Also added syncronisation on upload so only one upload can work at a time. 
This throttles the uploads so the bandwidth doesn't get flooded.

I've been running this for a week or so and I've had no problems with the uploading.
(I've other problems with thread 1 restarting multiple times, but don't think that's to do with the upload)
